### PR TITLE
Install epel to support installing jq on centos os for azure

### DIFF
--- a/deploy/linux/roles/prepare/tasks/installJQ.yml
+++ b/deploy/linux/roles/prepare/tasks/installJQ.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: install epel release to enusre that JQ is able to be installed most centos versions
+  yum:
+    name: epel-release
+    state: installed
+  become: yes
+
 - name: install JQ
   yum:
     name: jq


### PR DESCRIPTION
Install epel-release to support installing jq on Centos of Azure.