### PR TITLE
fix: skip error when nothing to do for node install

### DIFF
--- a/deploy/linux/roles/prepare/tasks/installNodeJs.yml
+++ b/deploy/linux/roles/prepare/tasks/installNodeJs.yml
@@ -3,6 +3,7 @@
   - name: download nodejs rpm
     shell: 'yum install https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y'
     become: yes
+    ignore_errors: yes
 
   - name: install nodejs from nodesource
     shell: 'yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1'


### PR DESCRIPTION
## Summary

Skip error when nothing to do when installing nodeJS

similar to https://github.com/newrelic/demo-nodetron/pull/57
